### PR TITLE
ensures에서 반환되는 변수명 사용하기

### DIFF
--- a/src/db_linked_list/db_linked_list_verus.rs
+++ b/src/db_linked_list/db_linked_list_verus.rs
@@ -31,7 +31,7 @@ verus! {
         }
     }
 
-    pub exec fn push_back(node: &PPtr<Node>, data: i32) -> PPtr<Node>
+    pub exec fn push_back(node: &PPtr<Node>, data: i32) -> (result: PPtr<Node>)
         requires
             node.well_formed(),
         ensures
@@ -60,7 +60,7 @@ verus! {
         new_node
     }
 
-    pub exec fn new_node(data: i32) -> PPtr<Node>
+    pub exec fn new_node(data: i32) -> (result: PPtr<Node>)
         ensures
             result.well_formed(),
             result.is_tail(),


### PR DESCRIPTION
이러면 `result`가 선언되지 않은 변수라는 에러는 싹 사라지고 27개의 새로운 에러가 나타납니당